### PR TITLE
landlock/syscall: use syscall.AllThreadsSyscall{,6} directly

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,4 @@ module github.com/landlock-lsm/go-landlock
 
 go 1.16
 
-require (
-	golang.org/x/sys v0.0.0-20210823070655-63515b42dcdf
-	kernel.org/pub/linux/libs/security/libcap/psx v1.2.51
-)
+require golang.org/x/sys v0.0.0-20210823070655-63515b42dcdf

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,2 @@
 golang.org/x/sys v0.0.0-20210823070655-63515b42dcdf h1:2ucpDCmfkl8Bd/FsLtiD653Wf96cW37s+iGx93zsu4k=
 golang.org/x/sys v0.0.0-20210823070655-63515b42dcdf/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-kernel.org/pub/linux/libs/security/libcap/psx v1.2.51 h1:VXVXjnTUsA9zeHIolNb6moSXZavDe1pD8Q0lPXZEOwc=
-kernel.org/pub/linux/libs/security/libcap/psx v1.2.51/go.mod h1:+l6Ee2F59XiJ2I6WR5ObpC1utCQJZ/VLsEbQCD8RG24=

--- a/landlock/syscall/landlock.go
+++ b/landlock/syscall/landlock.go
@@ -19,7 +19,6 @@ import (
 	"unsafe"
 
 	"golang.org/x/sys/unix"
-	"kernel.org/pub/linux/libs/security/libcap/psx"
 )
 
 // Landlock access rights, for use in "access" bit fields.
@@ -111,7 +110,7 @@ func LandlockAddRule(rulesetFd int, ruleType int, ruleAttr unsafe.Pointer, flags
 // AllThreadsLandlockRestrictSelf enforces the given ruleset on all OS
 // threads belonging to the current process.
 func AllThreadsLandlockRestrictSelf(rulesetFd int, flags int) (err error) {
-	_, _, e1 := psx.Syscall3(unix.SYS_LANDLOCK_RESTRICT_SELF, uintptr(rulesetFd), uintptr(flags), 0)
+	_, _, e1 := syscall.AllThreadsSyscall(unix.SYS_LANDLOCK_RESTRICT_SELF, uintptr(rulesetFd), uintptr(flags), 0)
 	if e1 != 0 {
 		err = syscall.Errno(e1)
 	}
@@ -120,7 +119,7 @@ func AllThreadsLandlockRestrictSelf(rulesetFd int, flags int) (err error) {
 
 // AllThreadsPrctl is like unix.Prctl, but gets applied on all OS threads at the same time.
 func AllThreadsPrctl(option int, arg2 uintptr, arg3 uintptr, arg4 uintptr, arg5 uintptr) (err error) {
-	_, _, e1 := psx.Syscall6(syscall.SYS_PRCTL, uintptr(option), uintptr(arg2), uintptr(arg3), uintptr(arg4), uintptr(arg5), 0)
+	_, _, e1 := syscall.AllThreadsSyscall6(syscall.SYS_PRCTL, uintptr(option), uintptr(arg2), uintptr(arg3), uintptr(arg4), uintptr(arg5), 0)
 	if e1 != 0 {
 		err = syscall.Errno(e1)
 	}


### PR DESCRIPTION
Go 1.16 added the `AllThreadsSyscall{,6}` functions to the `syscall`
package. The `kernel.org/pub/linux/libs/security/libcap/psx` package
merely wraps these for Go 1.16 and newer (and implements them using cgo
for older Go versions).

This package's `go.mod` specifies version 1.16. Thus,
`AllThreadsSyscall{,6}` can be used directly from package `syscall`.