### PR TITLE
Add Landlock V2 support.

### DIFF
--- a/landlock/abi_versions.go
+++ b/landlock/abi_versions.go
@@ -16,6 +16,10 @@ var abiInfos = []abiInfo{
 		version:           1,
 		supportedAccessFS: (1 << 13) - 1,
 	},
+	{
+		version:           2,
+		supportedAccessFS: (1 << 14) - 1,
+	},
 }
 
 // getSupportedABIVersion returns the kernel-supported ABI version.

--- a/landlock/accessfs.go
+++ b/landlock/accessfs.go
@@ -19,6 +19,7 @@ var flagNames = []string{
 	"make_fifo",
 	"make_block",
 	"make_sym",
+	"refer",
 }
 
 // AccessFSSet is a set of Landlockable file system access operations.
@@ -55,6 +56,10 @@ func (a AccessFSSet) isSubset(b AccessFSSet) bool {
 
 func (a AccessFSSet) intersect(b AccessFSSet) AccessFSSet {
 	return a & b
+}
+
+func (a AccessFSSet) union(b AccessFSSet) AccessFSSet {
+	return a | b
 }
 
 func (a AccessFSSet) isEmpty() bool {

--- a/landlock/accessfs_test.go
+++ b/landlock/accessfs_test.go
@@ -46,6 +46,7 @@ func TestPrettyPrint(t *testing.T) {
 		{a: ll.AccessFSMakeFifo, want: "{make_fifo}"},
 		{a: ll.AccessFSMakeBlock, want: "{make_block}"},
 		{a: ll.AccessFSMakeSym, want: "{make_sym}"},
+		{a: ll.AccessFSRefer, want: "{refer}"},
 		{a: ll.AccessFSReadFile | 1<<63, want: "{read_file,1<<63}"},
 	} {
 		got := tc.a.String()

--- a/landlock/config_test.go
+++ b/landlock/config_test.go
@@ -14,7 +14,7 @@ func TestConfigString(t *testing.T) {
 	}{
 		{
 			cfg:  Config{handledAccessFS: 0},
-			want: fmt.Sprintf("{Landlock V1; HandledAccessFS: %v}", AccessFSSet(0)),
+			want: fmt.Sprintf("{Landlock V0; HandledAccessFS: %v}", AccessFSSet(0)),
 		},
 		{
 			cfg:  Config{handledAccessFS: ll.AccessFSWriteFile},

--- a/landlock/landlock.go
+++ b/landlock/landlock.go
@@ -3,28 +3,26 @@
 // The following invocation will restrict all goroutines so that they
 // can only read from /usr, /bin and /tmp, and only write to /tmp:
 //
-//     err := landlock.V1.BestEffort().RestrictPaths(
+//     err := landlock.V2.BestEffort().RestrictPaths(
 //         landlock.RODirs("/usr", "/bin"),
 //         landlock.RWDirs("/tmp"),
 //     )
 //
-// This will restrict file access using Landlock V1, if available. If
+// This will restrict file access using Landlock V2, if available. If
 // unavailable, it will attempt using earlier Landlock versions than
 // the one requested. If no Landlock version is available, it will
 // still succeed, without restricting file accesses.
 //
 // More possible invocations
 //
-// landlock.V1.RestrictPaths(...) enforces the given rules using the
-// capabilities of Landlock V1, but returns an error if that is not
+// landlock.V2.RestrictPaths(...) enforces the given rules using the
+// capabilities of Landlock V2, but returns an error if that is not
 // available.
 //
 // Landlock ABI versioning
 //
 // Callers need to identify at which ABI level they want to use
 // Landlock and call RestrictPaths on the corresponding ABI constant.
-// Currently the only available ABI variant is V1, which restricts
-// basic filesystem operations.
 //
 // When new Landlock versions become available in landlock, users
 // will need to upgrade their usages manually to higher Landlock
@@ -42,7 +40,10 @@
 // Enabling Landlock implicitly turns off the following file system
 // features:
 //
-// - File reparenting: renaming or linking a file to a different parent directory is always denied.
+// - File reparenting: renaming or linking a file to a different parent directory is denied,
+//   unless it is explicitly enabled on both directories with the "Refer" access modifier,
+//   and the new target directory does not grant the file additional rights through its
+//   Landlock access rules.
 //
 // - Filesystem topology modification: arbitrary mounts are always denied.
 //

--- a/landlock/restrict.go
+++ b/landlock/restrict.go
@@ -9,23 +9,38 @@ import (
 	"golang.org/x/sys/unix"
 )
 
+// downgrade calculates the actual ruleset to be enforced given the
+// current kernel's Landlock ABI level.
+//
+// It establishes that opt.accessFS ⊆ handledAccessFS ⊆ abi.supportedAccessFS.
 func downgrade(handledAccessFS AccessFSSet, opts []PathOpt, abi abiInfo) (AccessFSSet, []PathOpt) {
 	handledAccessFS = handledAccessFS.intersect(abi.supportedAccessFS)
 
 	resOpts := make([]PathOpt, len(opts))
 	copy(resOpts, opts)
 	for i := 0; i < len(resOpts); i++ {
+		// In case that "refer" is requested on a path, we
+		// require Landlock V2+, or we have to downgrade to V0.
+		// You can't get the refer capability with V1, but linking/
+		// renaming files is always implicitly restricted.
+		if hasRefer(resOpts[i].accessFS) && !hasRefer(handledAccessFS) {
+			return 0, nil // Use "ABI V0" (do nothing)
+		}
 		resOpts[i].accessFS = resOpts[i].accessFS.intersect(handledAccessFS)
 	}
 	return handledAccessFS, resOpts
 }
 
-// The actual restrictPaths implementation.
+func hasRefer(a AccessFSSet) bool {
+	return a&ll.AccessFSRefer != 0
+}
+
+// restrictPaths is the actual RestrictPaths implementation.
 func restrictPaths(c Config, opts ...PathOpt) error {
 	handledAccessFS := c.handledAccessFS
 	// Check validity of options early.
 	for _, opt := range opts {
-		if opt.enforceSubset && !opt.accessFS.isSubset(handledAccessFS) {
+		if !opt.compatibleWithHandledAccessFS(handledAccessFS) {
 			return fmt.Errorf("too broad option %v: %w", opt.accessFS, unix.EINVAL)
 		}
 	}
@@ -34,11 +49,14 @@ func restrictPaths(c Config, opts ...PathOpt) error {
 	if c.bestEffort {
 		handledAccessFS, opts = downgrade(handledAccessFS, opts, abi)
 	}
-
 	if !handledAccessFS.isSubset(abi.supportedAccessFS) {
 		return fmt.Errorf("missing kernel Landlock support. Got Landlock ABI v%v, wanted %v", abi.version, c.String())
 	}
 
+	// TODO: This might be incorrect - the "refer" permission is
+	// always implicit, even in Landlock V1. So enabling Landlock
+	// on a Landlock V1 kernel without any handled access rights
+	// will still forbid linking files between directories.
 	if handledAccessFS.isEmpty() {
 		return nil // Success: Nothing to restrict.
 	}

--- a/landlock/restrict_test.go
+++ b/landlock/restrict_test.go
@@ -1,6 +1,10 @@
 package landlock
 
-import "testing"
+import (
+	"testing"
+
+	ll "github.com/landlock-lsm/go-landlock/landlock/syscall"
+)
 
 func TestDowngrade(t *testing.T) {
 	for _, tc := range []struct {
@@ -12,6 +16,8 @@ func TestDowngrade(t *testing.T) {
 
 		WantHandled   AccessFSSet
 		WantRequested AccessFSSet
+
+		WantFallbackToV0 bool
 	}{
 		{
 			Name:          "RestrictHandledToSupported",
@@ -37,12 +43,38 @@ func TestDowngrade(t *testing.T) {
 			WantHandled:   0b0,
 			WantRequested: 0b0,
 		},
+		{
+			Name:          "ReferSupportedOnV2",
+			SupportedABI:  2,
+			Handled:       ll.AccessFSRefer | ll.AccessFSReadFile,
+			Requested:     ll.AccessFSRefer | ll.AccessFSReadFile,
+			WantHandled:   ll.AccessFSRefer | ll.AccessFSReadFile,
+			WantRequested: ll.AccessFSRefer | ll.AccessFSReadFile,
+		},
+		{
+			Name:             "ReferNotSupportedOnV1",
+			SupportedABI:     1,
+			Handled:          ll.AccessFSRefer | ll.AccessFSReadFile,
+			Requested:        ll.AccessFSRefer | ll.AccessFSReadFile,
+			WantFallbackToV0: true,
+		},
 	} {
 		t.Run(tc.Name, func(t *testing.T) {
 			abi := abiInfos[tc.SupportedABI]
 
 			opts := []PathOpt{PathAccess(tc.Requested, "foo")}
 			gotHandled, gotOpts := downgrade(tc.Handled, opts, abi)
+
+			if tc.WantFallbackToV0 {
+				if gotHandled != 0 {
+					t.Errorf(
+						"downgrade(%v, %v, ABIv%d) = %v, %v; want fallback to V0",
+						tc.Handled, tc.Requested, tc.SupportedABI,
+						gotHandled, gotOpts,
+					)
+				}
+				return
+			}
 
 			if len(gotOpts) != 1 {
 				t.Fatalf("wrong number of opts returned: got %d, want 1", len(gotOpts))

--- a/landlock/syscall/landlock.go
+++ b/landlock/syscall/landlock.go
@@ -40,6 +40,7 @@ const (
 	AccessFSMakeFifo   = unix.LANDLOCK_ACCESS_FS_MAKE_FIFO
 	AccessFSMakeBlock  = unix.LANDLOCK_ACCESS_FS_MAKE_BLOCK
 	AccessFSMakeSym    = unix.LANDLOCK_ACCESS_FS_MAKE_SYM
+	AccessFSRefer      = 1 << 13 // unix.LANDLOCK_ACCESS_FS_REFER
 )
 
 // RulesetAttr is the Landlock ruleset definition.

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -4,11 +4,11 @@
 # can interfere with each other.
 
 enter () {
-    printf "[Test] %60s" "$*"
+    printf "  [Test] %60s" "$*"
 }
 
 success () {
-    echo -e " \e[1;32m[ok]\e[0m"
+    echo -e " \e[1;32m[pass]\e[0m"
 }
 
 fail () {
@@ -49,20 +49,29 @@ expect_failure() {
 
 # Run
 run() {
-    "${CMD}" -v -ro /bin /usr $* >stdout.txt 2>stderr.txt
+    "${CMD}" "-${LANDLOCK_VERSION}" -v -strict -ro /bin /usr $* >stdout.txt 2>stderr.txt
 }
-
-CMD="$(pwd)/bin/landlock-restrict"
 
 if [ ! -f "go.mod" ] || [ "$(head -n1 go.mod)" != "module github.com/landlock-lsm/go-landlock" ]; then
     echo "Need to run from go-landlock directory"
     exit 1
 fi
 
+CMD="$(pwd)/bin/landlock-restrict"
 if [ ! -f "${CMD}" ]; then
-    echo "Rebuilding Sandboxing command"
-    go build -o "${CMD}" cmd/landlock-restrict/main.go
+    echo "Sandboxing command does not exist: ${CMD} Building."
+    mkdir -p bin
+    go build -o "$CMD" cmd/landlock-restrict/main.go
 fi
+
+ABICMD="$(pwd)/bin/landlock-abi-version"
+if [ ! -f "${ABICMD}" ]; then
+    echo "Sandboxing command does not exist: ${ABICMD} Building."
+    mkdir -p bin
+    go build -o "$ABICMD" cmd/landlock-abi-version/main.go
+fi
+
+SUPPORTED_LANDLOCK_VERSION=$("${ABICMD}")
 
 TMPDIR=$(mktemp -t -d go-landlock-test.XXXXXX)
 echo "Running in ${TMPDIR}"
@@ -73,59 +82,74 @@ trap shutdown EXIT
 mkdir -p foo
 echo lolcat > foo/lolcat.txt
 
-# Tests
-enter "No sandboxing, read works"
-/bin/cat foo/lolcat.txt > /dev/null
-expect_success "reading file should have worked"
+for LANDLOCK_VERSION in $(seq 1 "${SUPPORTED_LANDLOCK_VERSION}"); do
+    echo
+    echo "LANDLOCK VERSION ${LANDLOCK_VERSION}"
 
-enter "No permissions, doing nothing succeeds"
-run -- /bin/true
-expect_success "doing nothing should succeed"
+    # Tests
+    enter "No sandboxing, read works"
+    /bin/cat foo/lolcat.txt > /dev/null
+    expect_success "reading file should have worked"
 
-enter "No permissions, read fails"
-run -- /bin/cat foo/lolcat.txt
-expect_failure "should have failed to read file"
+    enter "No permissions, doing nothing succeeds"
+    run -- /bin/true
+    expect_success "doing nothing should succeed"
 
-enter "Read permissions on dir (relative path), read works"
-run -ro "foo" -- /bin/cat foo/lolcat.txt
-expect_success "should have read the file"
+    enter "No permissions, read fails"
+    run -- /bin/cat foo/lolcat.txt
+    expect_failure "should have failed to read file"
 
-enter "Read permissions on dir (full path), read works"
-run -ro "${TMPDIR}/foo" -- /bin/cat foo/lolcat.txt
-expect_success "should have read the file"
+    enter "Read permissions on dir (relative path), read works"
+    run -ro "foo" -- /bin/cat foo/lolcat.txt
+    expect_success "should have read the file"
 
-enter "File-read permissions on file, read works"
-run -rofiles "foo/lolcat.txt" -- /bin/cat foo/lolcat.txt
-expect_success "should have read the file"
+    enter "Read permissions on dir (full path), read works"
+    run -ro "${TMPDIR}/foo" -- /bin/cat foo/lolcat.txt
+    expect_success "should have read the file"
 
-enter "File-read permissions on dir, read works"
-run -rofiles "foo" -- /bin/cat foo/lolcat.txt
-expect_success "should have read the file"
+    enter "Read permissions on file, read works"
+    run -rofiles "foo/lolcat.txt" -- /bin/cat foo/lolcat.txt
+    expect_success "should have read the file"
 
-enter "Read-only permissions on dir, creating file fails"
-run -ro "foo" -- /bin/touch foo/fail
-expect_failure "should not be able to create file"
+    enter "File-read permissions on dir, read works"
+    run -rofiles "foo" -- /bin/cat foo/lolcat.txt
+    expect_success "should have read the file"
 
-enter "RW permissions on dir, creating file succeeds"
-run -rw "foo" -- /bin/touch foo/succeed
-expect_success "should be able to create file"
+    enter "Read-only permissions on dir, creating file fails"
+    run -ro "foo" -- /bin/touch foo/fail
+    expect_failure "should not be able to create file"
 
-enter "Read-only permissions on dir, removing file fails"
-run -ro "foo" -- /bin/rm foo/succeed
-expect_failure "should not be able to remove file"
+    enter "RW permissions on dir, creating file succeeds"
+    run -rw "foo" -- /bin/touch foo/succeed
+    expect_success "should be able to create file"
 
-enter "RW permissions on dir, removing file succeeds"
-run -rw "foo" -- /bin/rm foo/succeed
-expect_success "should be able to remove file"
+    enter "Read-only permissions on dir, removing file fails"
+    run -ro "foo" -- /bin/rm foo/succeed
+    expect_failure "should not be able to remove file"
 
-enter "Read-only permissions on dir, mkfifo fails"
-run -ro "foo" -- /bin/mkfifo foo/fifo
-expect_failure "should not be able to create file"
+    enter "RW permissions on dir, removing file succeeds"
+    run -rw "foo" -- /bin/rm foo/succeed
+    expect_success "should be able to remove file"
 
-enter "RW permissions on dir, mkfifo succeeds"
-run -rw "foo" -- /bin/mkfifo foo/fifo
-expect_success "should be able to create file"
-rm foo/fifo
+    enter "Read-only permissions on dir, mkfifo fails"
+    run -ro "foo" -- /bin/mkfifo foo/fifo
+    expect_failure "should not be able to create file"
+
+    enter "RW permissions on dir, mkfifo succeeds"
+    run -rw "foo" -- /bin/mkfifo foo/fifo
+    expect_success "should be able to create file"
+    rm foo/fifo
+
+    enter "Linking files between directories with refer permission"
+    mkdir bar
+    run -rw +refer foo bar -- /bin/ln foo/lolcat.txt bar/lolcat.txt
+    case "${LANDLOCK_VERSION}" in
+        1) expect_failure "Landlock V1: SHOULD NOT be able to move a file between directories" ;;
+        2) expect_success "Landlock V2: SHOULD be able to move a file between directories" ;;
+    esac
+    rm -f bar/lolcat.txt
+    rmdir bar
+done
 
 echo
-echo "All tests executed."
+echo "PASS"


### PR DESCRIPTION
This adds preliminary support for the upcoming Landlock ABI V2.

In addition to the existing file system access rights, it is now
possible to move or link files across different directories with the
new 'refer' access right. (For details, see Landlock documentation.)

Changes in the library:

  * Introduce `landlock.V2` config as a way to explicitly ask for
    this ABI level for users.
  * Introduce `syscall.AccessFSRefer` constant for the new "refer" right.
  * Add PathOpt.WithRefer() method so that users can ask for "refer" right.
  * The semantics of `RWDirs()` stay unmodified.

The 'refer' access right for a path may only be specified
handledAccessFS also contains it (i.e. by using the landlock.V2 config).

Upgrade path:

Callers using the `landlock.V1.BestEffort().RestrictPaths(...)` form
can switch to use `landlock.V2.BestEffort().RestrictPaths(...)`
with the same parameters instead. This change is compatible with before.

If you additionally desire to link or move files between directories,
make sure that both directories have the "refer" access right, by
calling .WithRefer() on their landlock.PathOpt objects. For example:

err := landlock.V2.RestrictPaths(
    landlock.RWDirs("/src", "/dest").WithRefer(),
)

NOTE: Requiring the "refer" access right is incompatible with kernels
before 5.19. If you want to use Landlock with earlier kernels, do not
ask for that permission.

In particular, using "best effort mode" in combination with the refer
right will downgrade to "doing nothing" on kernels below 5.19,
as linking and moving files would otherwise not work:

err := landlock.V2.BestEffort().RestrictPaths(
    landlock.RWDirs("/src", "/dest").WithRefer(),
)

Resolves #20.