### PR TITLE
Add Landlock V2 support.

### DIFF
--- a/landlock/abi_versions.go
+++ b/landlock/abi_versions.go
@@ -16,6 +16,10 @@ var abiInfos = []abiInfo{
 		version:           1,
 		supportedAccessFS: (1 << 13) - 1,
 	},
+	{
+		version:           2,
+		supportedAccessFS: (1 << 14) - 1,
+	},
 }
 
 // getSupportedABIVersion returns the kernel-supported ABI version.

--- a/landlock/abi_versions_test.go
+++ b/landlock/abi_versions_test.go
@@ -13,10 +13,10 @@ func TestAbiVersionsIncrementing(t *testing.T) {
 }
 
 func TestSupportedAccessFS(t *testing.T) {
-	got := abiInfos[1].supportedAccessFS
+	got := abiInfos[2].supportedAccessFS
 	want := supportedAccessFS
 
 	if got != want {
-		t.Errorf("V1 supported access FS: got %x, want %x", got, want)
+		t.Errorf("V2 supported access FS: got %x, want %x", got, want)
 	}
 }

--- a/landlock/accessfs.go
+++ b/landlock/accessfs.go
@@ -19,12 +19,13 @@ var flagNames = []string{
 	"make_fifo",
 	"make_block",
 	"make_sym",
+	"refer",
 }
 
 // AccessFSSet is a set of Landlockable file system access operations.
 type AccessFSSet uint64
 
-var supportedAccessFS = AccessFSSet((1 << 13) - 1)
+var supportedAccessFS = AccessFSSet((1 << len(flagNames)) - 1)
 
 func (a AccessFSSet) String() string {
 	if a.isEmpty() {
@@ -55,6 +56,10 @@ func (a AccessFSSet) isSubset(b AccessFSSet) bool {
 
 func (a AccessFSSet) intersect(b AccessFSSet) AccessFSSet {
 	return a & b
+}
+
+func (a AccessFSSet) union(b AccessFSSet) AccessFSSet {
+	return a | b
 }
 
 func (a AccessFSSet) isEmpty() bool {

--- a/landlock/accessfs_test.go
+++ b/landlock/accessfs_test.go
@@ -46,11 +46,23 @@ func TestPrettyPrint(t *testing.T) {
 		{a: ll.AccessFSMakeFifo, want: "{make_fifo}"},
 		{a: ll.AccessFSMakeBlock, want: "{make_block}"},
 		{a: ll.AccessFSMakeSym, want: "{make_sym}"},
+		{a: ll.AccessFSRefer, want: "{refer}"},
 		{a: ll.AccessFSReadFile | 1<<63, want: "{read_file,1<<63}"},
 	} {
 		got := tc.a.String()
 		if got != tc.want {
 			t.Errorf("AccessFSSet(%08x).String() = %q, want %q", uint64(tc.a), got, tc.want)
+		}
+	}
+}
+
+func TestValid(t *testing.T) {
+	for _, a := range []AccessFSSet{
+		ll.AccessFSExecute, ll.AccessFSMakeDir, ll.AccessFSMakeSym, ll.AccessFSRefer,
+	} {
+		gotIsValid := a.valid()
+		if !gotIsValid {
+			t.Errorf("%v.valid() = false, want true", a)
 		}
 	}
 }

--- a/landlock/config.go
+++ b/landlock/config.go
@@ -33,6 +33,10 @@ var (
 	V1 = Config{
 		handledAccessFS: abiInfos[1].supportedAccessFS,
 	}
+	// Landlock V2 support (V1 + file reparenting between different directories)
+	V2 = Config{
+		handledAccessFS: abiInfos[2].supportedAccessFS,
+	}
 )
 
 // The Landlock configuration describes the desired set of
@@ -86,14 +90,15 @@ func MustConfig(args ...interface{}) Config {
 // String builds a human-readable representation of the Config.
 func (c Config) String() string {
 	abi := abiInfo{version: -1} // invalid
-	for _, a := range abiInfos {
+	for i := len(abiInfos) - 1; i >= 0; i-- {
+		a := abiInfos[i]
 		if c.handledAccessFS.isSubset(a.supportedAccessFS) {
 			abi = a
 		}
 	}
 
 	var desc = c.handledAccessFS.String()
-	if abi.supportedAccessFS == c.handledAccessFS {
+	if abi.supportedAccessFS == c.handledAccessFS && c.handledAccessFS != 0 {
 		desc = "all"
 	}
 
@@ -129,6 +134,41 @@ type PathOpt struct {
 	accessFS      AccessFSSet
 	enforceSubset bool // enforce that accessFS is a subset of cfg.handledAccessFS
 	paths         []string
+}
+
+// withRights adds the given access rights to the right enforced in the path option
+// and returns the result as a new PathOpt.
+func (p PathOpt) withRights(a AccessFSSet) PathOpt {
+	return PathOpt{
+		accessFS:      p.accessFS.union(a),
+		enforceSubset: p.enforceSubset,
+		paths:         p.paths,
+	}
+}
+
+// WithRefer adds the "refer" access right to a path option.
+//
+// Notably, asking for the "refer" access right does not work on
+// kernels below 5.19. In best effort mode, this will fall back to not
+// using Landlock enforcement at all on these kernel versions. If you
+// want to use Landlock on these kernels, do not use the "refer"
+// access right.
+func (p PathOpt) WithRefer() PathOpt {
+	return p.withRights(ll.AccessFSRefer)
+}
+
+func (p PathOpt) String() string {
+	return fmt.Sprintf("REQUIRE %v for paths %v", p.accessFS, p.paths)
+}
+
+func (p PathOpt) compatibleWithHandledAccessFS(handledAccessFS AccessFSSet) bool {
+	a := p.accessFS
+	if !p.enforceSubset {
+		// Even when we are lax about enforcing flag subsets,
+		// the "refer" flag always gets checked.
+		a = a.intersect(ll.AccessFSRefer)
+	}
+	return a.isSubset(handledAccessFS)
 }
 
 // PathAccess is a RestrictPaths() option that grants the access right
@@ -208,12 +248,12 @@ func RWFiles(paths ...string) PathOpt {
 // that it can only read from /usr, /bin and /tmp, and only write to
 // /tmp:
 //
-//   err := landlock.V1.RestrictPaths(
+//   err := landlock.V2.RestrictPaths(
 //       landlock.RODirs("/usr", "/bin"),
 //       landlock.RWDirs("/tmp"),
 //   )
 //   if err != nil {
-//       log.Fatalf("landlock.V1.RestrictPaths(): %v", err)
+//       log.Fatalf("landlock.V2.RestrictPaths(): %v", err)
 //   }
 //
 // RestrictPaths returns an error if any of the given paths does not
@@ -269,6 +309,8 @@ func RWFiles(paths ...string) PathOpt {
 //
 // • Creating (or renaming or linking) a symbolic link (V1+)
 //
+// • Renaming or linking a file between directories (V2+)
+//
 // Future versions of Landlock will be able to inhibit more operations.
 // Quoting the Landlock documentation:
 //
@@ -289,7 +331,8 @@ func RWFiles(paths ...string) PathOpt {
 // In V1, this means reading files, listing directories and executing files.
 //
 // • RWDirs() selects access rights in the group "for reading", "for writing" and
-// "for directory manipulation". In V1, this grants the full set of access rights.
+// "for directory manipulation". This grants the full set of access rights which are
+// available within the configuration.
 //
 // • ROFiles() is like RODirs(), but does not select directory-specific access rights.
 // In V1, this means reading and executing files.

--- a/landlock/config_test.go
+++ b/landlock/config_test.go
@@ -14,7 +14,7 @@ func TestConfigString(t *testing.T) {
 	}{
 		{
 			cfg:  Config{handledAccessFS: 0},
-			want: fmt.Sprintf("{Landlock V1; HandledAccessFS: %v}", AccessFSSet(0)),
+			want: fmt.Sprintf("{Landlock V0; HandledAccessFS: %v}", AccessFSSet(0)),
 		},
 		{
 			cfg:  Config{handledAccessFS: ll.AccessFSWriteFile},
@@ -41,13 +41,17 @@ func TestConfigString(t *testing.T) {
 }
 
 func TestNewConfig(t *testing.T) {
-	c, err := NewConfig(AccessFSSet(ll.AccessFSWriteFile))
-	if err != nil {
-		t.Errorf("NewConfig(): expected success, got %v", err)
-	}
-	want := AccessFSSet(ll.AccessFSWriteFile)
-	if c.handledAccessFS != want {
-		t.Errorf("c.handledAccessFS = %v, want %v", c.handledAccessFS, want)
+	for _, a := range []AccessFSSet{
+		ll.AccessFSWriteFile, ll.AccessFSRefer,
+	} {
+		c, err := NewConfig(a)
+		if err != nil {
+			t.Errorf("NewConfig(): expected success, got %v", err)
+		}
+		want := a
+		if c.handledAccessFS != want {
+			t.Errorf("c.handledAccessFS = %v, want %v", c.handledAccessFS, want)
+		}
 	}
 }
 
@@ -72,6 +76,7 @@ func TestNewConfigFailures(t *testing.T) {
 		// May not specify two AccessFSSets
 		{AccessFSSet(ll.AccessFSWriteFile), AccessFSSet(ll.AccessFSReadFile)},
 		// May not specify an unsupported AccessFSSet value
+		{AccessFSSet(1 << 15)},
 		{AccessFSSet(1 << 63)},
 	} {
 		_, err := NewConfig(args...)

--- a/landlock/landlock.go
+++ b/landlock/landlock.go
@@ -3,28 +3,26 @@
 // The following invocation will restrict all goroutines so that they
 // can only read from /usr, /bin and /tmp, and only write to /tmp:
 //
-//     err := landlock.V1.BestEffort().RestrictPaths(
+//     err := landlock.V2.BestEffort().RestrictPaths(
 //         landlock.RODirs("/usr", "/bin"),
 //         landlock.RWDirs("/tmp"),
 //     )
 //
-// This will restrict file access using Landlock V1, if available. If
+// This will restrict file access using Landlock V2, if available. If
 // unavailable, it will attempt using earlier Landlock versions than
 // the one requested. If no Landlock version is available, it will
 // still succeed, without restricting file accesses.
 //
 // More possible invocations
 //
-// landlock.V1.RestrictPaths(...) enforces the given rules using the
-// capabilities of Landlock V1, but returns an error if that is not
+// landlock.V2.RestrictPaths(...) enforces the given rules using the
+// capabilities of Landlock V2, but returns an error if that is not
 // available.
 //
 // Landlock ABI versioning
 //
 // Callers need to identify at which ABI level they want to use
 // Landlock and call RestrictPaths on the corresponding ABI constant.
-// Currently the only available ABI variant is V1, which restricts
-// basic filesystem operations.
 //
 // When new Landlock versions become available in landlock, users
 // will need to upgrade their usages manually to higher Landlock
@@ -46,7 +44,10 @@
 // Enabling Landlock implicitly turns off the following file system
 // features:
 //
-// - File reparenting: renaming or linking a file to a different parent directory is always denied.
+// - File reparenting: renaming or linking a file to a different parent directory is denied,
+//   unless it is explicitly enabled on both directories with the "Refer" access modifier,
+//   and the new target directory does not grant the file additional rights through its
+//   Landlock access rules.
 //
 // - Filesystem topology modification: arbitrary mounts are always denied.
 //

--- a/landlock/restrict.go
+++ b/landlock/restrict.go
@@ -9,23 +9,38 @@ import (
 	"golang.org/x/sys/unix"
 )
 
+// downgrade calculates the actual ruleset to be enforced given the
+// current kernel's Landlock ABI level.
+//
+// It establishes that opt.accessFS ⊆ handledAccessFS ⊆ abi.supportedAccessFS.
 func downgrade(handledAccessFS AccessFSSet, opts []PathOpt, abi abiInfo) (AccessFSSet, []PathOpt) {
 	handledAccessFS = handledAccessFS.intersect(abi.supportedAccessFS)
 
 	resOpts := make([]PathOpt, len(opts))
 	copy(resOpts, opts)
 	for i := 0; i < len(resOpts); i++ {
+		// In case that "refer" is requested on a path, we
+		// require Landlock V2+, or we have to downgrade to V0.
+		// You can't get the refer capability with V1, but linking/
+		// renaming files is always implicitly restricted.
+		if hasRefer(resOpts[i].accessFS) && !hasRefer(handledAccessFS) {
+			return 0, nil // Use "ABI V0" (do nothing)
+		}
 		resOpts[i].accessFS = resOpts[i].accessFS.intersect(handledAccessFS)
 	}
 	return handledAccessFS, resOpts
 }
 
-// The actual restrictPaths implementation.
+func hasRefer(a AccessFSSet) bool {
+	return a&ll.AccessFSRefer != 0
+}
+
+// restrictPaths is the actual RestrictPaths implementation.
 func restrictPaths(c Config, opts ...PathOpt) error {
 	handledAccessFS := c.handledAccessFS
 	// Check validity of options early.
 	for _, opt := range opts {
-		if opt.enforceSubset && !opt.accessFS.isSubset(handledAccessFS) {
+		if !opt.compatibleWithHandledAccessFS(handledAccessFS) {
 			return fmt.Errorf("too broad option %v: %w", opt.accessFS, unix.EINVAL)
 		}
 	}
@@ -34,11 +49,14 @@ func restrictPaths(c Config, opts ...PathOpt) error {
 	if c.bestEffort {
 		handledAccessFS, opts = downgrade(handledAccessFS, opts, abi)
 	}
-
 	if !handledAccessFS.isSubset(abi.supportedAccessFS) {
 		return fmt.Errorf("missing kernel Landlock support. Got Landlock ABI v%v, wanted %v", abi.version, c.String())
 	}
 
+	// TODO: This might be incorrect - the "refer" permission is
+	// always implicit, even in Landlock V1. So enabling Landlock
+	// on a Landlock V1 kernel without any handled access rights
+	// will still forbid linking files between directories.
 	if handledAccessFS.isEmpty() {
 		return nil // Success: Nothing to restrict.
 	}

--- a/landlock/restrict_downgrade_test.go
+++ b/landlock/restrict_downgrade_test.go
@@ -2,6 +2,8 @@ package landlock
 
 import (
 	"testing"
+
+	ll "github.com/landlock-lsm/go-landlock/landlock/syscall"
 )
 
 func TestDowngrade(t *testing.T) {
@@ -14,6 +16,8 @@ func TestDowngrade(t *testing.T) {
 
 		WantHandled   AccessFSSet
 		WantRequested AccessFSSet
+
+		WantFallbackToV0 bool
 	}{
 		{
 			Name:          "RestrictHandledToSupported",
@@ -39,12 +43,38 @@ func TestDowngrade(t *testing.T) {
 			WantHandled:   0b0,
 			WantRequested: 0b0,
 		},
+		{
+			Name:          "ReferSupportedOnV2",
+			SupportedABI:  2,
+			Handled:       ll.AccessFSRefer | ll.AccessFSReadFile,
+			Requested:     ll.AccessFSRefer | ll.AccessFSReadFile,
+			WantHandled:   ll.AccessFSRefer | ll.AccessFSReadFile,
+			WantRequested: ll.AccessFSRefer | ll.AccessFSReadFile,
+		},
+		{
+			Name:             "ReferNotSupportedOnV1",
+			SupportedABI:     1,
+			Handled:          ll.AccessFSRefer | ll.AccessFSReadFile,
+			Requested:        ll.AccessFSRefer | ll.AccessFSReadFile,
+			WantFallbackToV0: true,
+		},
 	} {
 		t.Run(tc.Name, func(t *testing.T) {
 			abi := abiInfos[tc.SupportedABI]
 
 			opts := []PathOpt{PathAccess(tc.Requested, "foo")}
 			gotHandled, gotOpts := downgrade(tc.Handled, opts, abi)
+
+			if tc.WantFallbackToV0 {
+				if gotHandled != 0 {
+					t.Errorf(
+						"downgrade(%v, %v, ABIv%d) = %v, %v; want fallback to V0",
+						tc.Handled, tc.Requested, tc.SupportedABI,
+						gotHandled, gotOpts,
+					)
+				}
+				return
+			}
 
 			if len(gotOpts) != 1 {
 				t.Fatalf("wrong number of opts returned: got %d, want 1", len(gotOpts))

--- a/landlock/syscall/landlock.go
+++ b/landlock/syscall/landlock.go
@@ -40,6 +40,7 @@ const (
 	AccessFSMakeFifo   = unix.LANDLOCK_ACCESS_FS_MAKE_FIFO
 	AccessFSMakeBlock  = unix.LANDLOCK_ACCESS_FS_MAKE_BLOCK
 	AccessFSMakeSym    = unix.LANDLOCK_ACCESS_FS_MAKE_SYM
+	AccessFSRefer      = 1 << 13 // unix.LANDLOCK_ACCESS_FS_REFER
 )
 
 // RulesetAttr is the Landlock ruleset definition.


### PR DESCRIPTION
This adds support for the upcoming Landlock ABI V2.

In addition to the existing file system access rights, it is now
possible to move or link files across different directories with the
new 'refer' access right. (For details, see Landlock documentation.)

Changes in the library:

  * Introduce `landlock.V2` config as a way to explicitly ask for
    this ABI level for users.
  * Introduce `syscall.AccessFSRefer` constant for the new "refer" right.
  * Add PathOpt.WithRefer() method so that users can ask for "refer" right.
  * The semantics of `RWDirs()` stay unmodified.

The 'refer' access right for a path may only be specified
handledAccessFS also contains it (i.e. by using the landlock.V2 config).

Upgrade path:

Callers using the `landlock.V1.BestEffort().RestrictPaths(...)` form
can switch to use `landlock.V2.BestEffort().RestrictPaths(...)`
with the same parameters instead. This change is compatible with before.

If you additionally desire to link or move files between directories,
make sure that both directories have the "refer" access right, by
calling .WithRefer() on their landlock.PathOpt objects. For example:

```
err := landlock.V2.RestrictPaths(
    landlock.RWDirs("/src", "/dest").WithRefer(),
)
```

NOTE: Requiring the "refer" access right is incompatible with kernels
before 5.19. If you want to use Landlock with earlier kernels, do not
ask for that permission.

In particular, this means that using "best effort mode" in combination
with the refer right will downgrade to "doing nothing" on kernels
below 5.19, as linking and moving files would otherwise not work:

```
// Downgrades to no Landlock enforcement on Linux kernels before 5.19.
err := landlock.V2.BestEffort().RestrictPaths(
    landlock.RWDirs("/src", "/dest").WithRefer(),
)
```

Resolves #20.