### PR TITLE
Add AccessFSTruncate to access rights that apply to files

### DIFF
--- a/landlock/config.go
+++ b/landlock/config.go
@@ -10,7 +10,7 @@ import (
 // Access permission sets for filesystem access.
 const (
 	// The set of access rights that only apply to files.
-	accessFile AccessFSSet = ll.AccessFSExecute | ll.AccessFSWriteFile | ll.AccessFSReadFile
+	accessFile AccessFSSet = ll.AccessFSExecute | ll.AccessFSWriteFile | ll.AccessFSTruncate | ll.AccessFSReadFile
 
 	// The set of access rights associated with read access to files and directories.
 	accessFSRead AccessFSSet = ll.AccessFSExecute | ll.AccessFSReadFile | ll.AccessFSReadDir


### PR DESCRIPTION
AccessFSTruncate works also on a per file basis and can from my understanding be used to e.g. overwrite an existing target file without granting access to directories. Here is an minimal [example gist](https://gist.github.com/ngergs/b2ace345fbf8d682da33b5a4d869bb04).

Tested it with this patched version and it worked.