### PR TITLE
landlock/config: ensure AccessFSTruncate is included in AccessFile

### DIFF
--- a/landlock/config.go
+++ b/landlock/config.go
@@ -10,7 +10,7 @@ import (
 // Access permission sets for filesystem access.
 const (
 	// The set of access rights that only apply to files.
-	accessFile AccessFSSet = ll.AccessFSExecute | ll.AccessFSWriteFile | ll.AccessFSReadFile
+	accessFile AccessFSSet = ll.AccessFSExecute | ll.AccessFSWriteFile | ll.AccessFSReadFile | ll.AccessFSTruncate
 
 	// The set of access rights associated with read access to files and directories.
 	accessFSRead AccessFSSet = ll.AccessFSExecute | ll.AccessFSReadFile | ll.AccessFSReadDir


### PR DESCRIPTION
I'm not 100% sure if this is intended or not, but it seems to me like `AccessFSTruncate` should be included in `accessFile` as `RWFile` does not get the truncat permission.