### PR TITLE
Support for Scoped access rights

### DIFF
--- a/cmd/landlock-restrict-scoped/main.go
+++ b/cmd/landlock-restrict-scoped/main.go
@@ -1,0 +1,48 @@
+// landlock-restrict-scoped executes a process with Landlock scope restrictions
+//
+// This is an example tool which does not provide backwards
+// compatibility guarantees.
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"syscall"
+
+	"github.com/landlock-lsm/go-landlock/landlock"
+)
+
+func usage() {
+	var (
+		out  = flag.CommandLine.Output()
+		name = os.Args[0]
+	)
+	fmt.Fprintf(out, "Usage of %s:\n", name)
+	flag.PrintDefaults()
+	fmt.Fprintf(out, "\nExample usages:\n")
+	fmt.Fprintf(out, "  %s -- /usr/bin/kill -USR1 $$\n", name)
+}
+
+func main() {
+	flag.Usage = usage
+	flag.Parse()
+
+	var cmd []string
+	if flag.NArg() > 1 {
+		cmd = flag.Args()
+	} else {
+		log.Println("missing command to call, using /bin/bash")
+		cmd = []string{"/bin/bash"}
+	}
+
+	if err := landlock.V6.RestrictScoped(); err != nil {
+		log.Fatalf("landlock RestrictScoped: %v", err)
+	}
+
+	log.Printf("Starting %v", cmd)
+	if err := syscall.Exec(cmd[0], cmd, os.Environ()); err != nil {
+		log.Fatalf("execve: %v", err)
+	}
+}

--- a/cmd/landlock-restrict/main.go
+++ b/cmd/landlock-restrict/main.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"strconv"
 	"strings"
 	"syscall"
 
@@ -11,7 +12,8 @@ import (
 )
 
 func parseFlags(args []string) (verbose bool, cfg landlock.Config, opts []landlock.Rule, cmd []string) {
-	cfg = landlock.V5
+	configs := []landlock.Config{landlock.V1, landlock.V2, landlock.V3, landlock.V4, landlock.V5, landlock.V6}
+	cfg = configs[len(configs)-1]
 
 	takeArgs := func(makeOpt func(...string) landlock.FSRule) landlock.Rule {
 		var paths []string
@@ -48,26 +50,12 @@ func parseFlags(args []string) (verbose bool, cfg landlock.Config, opts []landlo
 ArgParsing:
 	for len(args) > 0 {
 		switch args[0] {
-		case "-5":
-			cfg = landlock.V5
-			args = args[1:]
-			continue
-		case "-4":
-			cfg = landlock.V4
-			args = args[1:]
-			continue
-		case "-3":
-			cfg = landlock.V3
-			args = args[1:]
-			continue
-		case "-2":
-			cfg = landlock.V2
-			args = args[1:]
-			continue
-		case "-1":
-			cfg = landlock.V1
-			args = args[1:]
-			continue
+		case "-1", "-2", "-3", "-4", "-5", "-6":
+			v, err := strconv.Atoi(args[0][1:])
+			if err != nil {
+				log.Fatal(err)
+			}
+			cfg = configs[v-1]
 		case "-strict":
 			bestEffort = false
 			args = args[1:]
@@ -122,14 +110,14 @@ func main() {
 		fmt.Println("Usage:")
 		fmt.Println("  landlock-restrict")
 		fmt.Println("     [-v]")
-		fmt.Println("     [-1] [-2] [-3] [-4] [-5] [-strict]")
+		fmt.Println("     [-1] [-2] [-3] [-4] [-5] [-6] [-strict]")
 		fmt.Println("     [-ro [+refer] PATH...] [-rw [+refer] [+ioctl_dev] PATH...]")
 		fmt.Println("     [-rofiles [+refer] PATH] [-rwfiles [+refer] PATH]")
 		fmt.Println("       -- COMMAND...")
 		fmt.Println()
 		fmt.Println("Options:")
 		fmt.Println("  -ro, -rw, -rofiles, -rwfiles   paths to restrict to")
-		fmt.Println("  -1, -2, -3, -4, -5             select Landlock version")
+		fmt.Println("  -1, -2, -3, -4, -5, -6         select Landlock version")
 		fmt.Println("  -strict                        use strict mode (instead of best effort)")
 		fmt.Println("  -v                             verbose logging")
 		fmt.Println()

--- a/landlock/abi_versions.go
+++ b/landlock/abi_versions.go
@@ -6,6 +6,7 @@ type abiInfo struct {
 	version            int
 	supportedAccessFS  AccessFSSet
 	supportedAccessNet AccessNetSet
+	supportedScoped    ScopedSet
 }
 
 var abiInfos = []abiInfo{
@@ -35,12 +36,19 @@ var abiInfos = []abiInfo{
 		supportedAccessFS:  (1 << 16) - 1,
 		supportedAccessNet: (1 << 2) - 1,
 	},
+	{
+		version:            6,
+		supportedAccessFS:  (1 << 16) - 1,
+		supportedAccessNet: (1 << 2) - 1,
+		supportedScoped:    (1 << 2) - 1,
+	},
 }
 
 func (a abiInfo) asConfig() Config {
 	return Config{
 		handledAccessFS:  a.supportedAccessFS,
 		handledAccessNet: a.supportedAccessNet,
+		scoped:           a.supportedScoped,
 	}
 }
 

--- a/landlock/lltest/lltest.go
+++ b/landlock/lltest/lltest.go
@@ -13,16 +13,12 @@ import (
 	ll "github.com/landlock-lsm/go-landlock/landlock/syscall"
 )
 
-// isRunningInSubprocess indicates whether we are currently running in a subprocess context.
-var isRunningInSubprocess = false
-
 // RunInSubprocess runs the given test function in a subprocess
 // and forwards its output.
 func RunInSubprocess(t *testing.T, f func()) {
 	t.Helper()
 
-	if os.Getenv("IS_SUBPROCESS") != "" {
-		isRunningInSubprocess = true
+	if IsRunningInSubprocess() {
 		f()
 		return
 	}
@@ -67,7 +63,7 @@ func RunInSubprocess(t *testing.T, f func()) {
 func TempDir(t testing.TB) string {
 	t.Helper()
 
-	if isRunningInSubprocess {
+	if IsRunningInSubprocess() {
 		dir, err := os.MkdirTemp("", "LandlockTestTempDir")
 		if err != nil {
 			t.Fatalf("os.MkdirTemp: %v", err)
@@ -84,4 +80,8 @@ func RequireABI(t testing.TB, want int) {
 	if v, err := ll.LandlockGetABIVersion(); err != nil || v < want {
 		t.Skipf("Requires Landlock >= V%v, got V%v (err=%v)", want, v, err)
 	}
+}
+
+func IsRunningInSubprocess() bool {
+	return os.Getenv("IS_SUBPROCESS") != ""
 }

--- a/landlock/opt.go
+++ b/landlock/opt.go
@@ -12,7 +12,7 @@ type Rule interface {
 	//
 	// It establishes that:
 	//
-	//   - rule.accessFS ⊆ handledAccessFS for PathRules
+	//   - rule.accessFS ⊆ handledAccessFS for FSRules
 	//   - rule.accessNet ⊆ handledAccessNet for NetRules
 	//
 	// If the rule is unsupportable under the given Config at

--- a/landlock/restrict.go
+++ b/landlock/restrict.go
@@ -50,13 +50,14 @@ func restrict(c Config, rules ...Rule) error {
 	// always implicit, even in Landlock V1. So enabling Landlock
 	// on a Landlock V1 kernel without any handled access rights
 	// will still forbid linking files between directories.
-	if c.handledAccessFS.isEmpty() && c.handledAccessNet.isEmpty() {
+	if c.handledAccessFS.isEmpty() && c.handledAccessNet.isEmpty() && c.scoped.isEmpty() {
 		return nil // Success: Nothing to restrict.
 	}
 
 	rulesetAttr := ll.RulesetAttr{
 		HandledAccessFS:  uint64(c.handledAccessFS),
 		HandledAccessNet: uint64(c.handledAccessNet),
+		Scoped:           uint64(c.scoped),
 	}
 	fd, err := ll.LandlockCreateRuleset(&rulesetAttr, 0)
 	if err != nil {

--- a/landlock/restrict_test.go
+++ b/landlock/restrict_test.go
@@ -501,6 +501,87 @@ func TestIoctlDev(t *testing.T) {
 	}
 }
 
+func TestRestrictScoped(t *testing.T) {
+	const name = "@abstract/go-landlock/test"
+
+	// Bring up an abstract Unix Domain Socket service in the
+	// parent process, which the subprocesses can dial.
+	if !lltest.IsRunningInSubprocess() {
+		ls, err := net.Listen("unix", name)
+		if err != nil {
+			t.Fatalf("net.Listen(unix:%q): %v", name, err)
+		}
+		defer ls.Close()
+	}
+
+	for _, tt := range []struct {
+		Name           string
+		EnableLandlock func() error
+		RequiredABI    int
+		WantDialErr    error
+		WantKillErr    error
+	}{
+		{
+			Name:           "Unrestricted",
+			RequiredABI:    0,
+			EnableLandlock: func() error { return nil },
+		},
+		{
+			Name:        "RestrictAbstractUnixSockets",
+			RequiredABI: 6,
+			EnableLandlock: func() error {
+				return landlock.MustConfig(
+					landlock.ScopedSet(ll.ScopeAbstractUnixSocket),
+				).Restrict()
+			},
+			WantDialErr: syscall.EPERM,
+		},
+		{
+			Name:        "RestrictSignal",
+			RequiredABI: 6,
+			EnableLandlock: func() error {
+				return landlock.MustConfig(
+					landlock.ScopedSet(ll.ScopeSignal),
+				).Restrict()
+			},
+			WantKillErr: syscall.EPERM,
+		},
+		{
+			Name:        "RestrictAll",
+			RequiredABI: 6,
+			EnableLandlock: func() error {
+				return landlock.V6.RestrictScoped()
+			},
+			WantDialErr: syscall.EPERM,
+			WantKillErr: syscall.EPERM,
+		},
+	} {
+		t.Run(tt.Name, func(t *testing.T) {
+			lltest.RunInSubprocess(t, func() {
+				lltest.RequireABI(t, tt.RequiredABI)
+
+				err := tt.EnableLandlock()
+				if err != nil {
+					t.Fatalf("Enabling Landlock: %v", err)
+				}
+
+				cs, err := net.Dial("unix", name)
+				if want := tt.WantDialErr; !errEqual(err, want) {
+					t.Errorf("Dial(unix:%q): err=%q, want %q", name, err, want)
+				}
+				if err == nil {
+					defer cs.Close()
+				}
+
+				killErr := syscall.Kill(os.Getppid(), syscall.SIGUSR1)
+				if want := tt.WantKillErr; killErr != want {
+					t.Errorf("Kill(ppid, USR1): err=%q, want %q", killErr, want)
+				}
+			})
+		})
+	}
+}
+
 func errEqual(got, want error) bool {
 	if got == nil && want == nil {
 		return true

--- a/landlock/scoped.go
+++ b/landlock/scoped.go
@@ -1,0 +1,35 @@
+package landlock
+
+// ScopedSet is a set of restrictable IPC scopes.
+//
+// When the scope is restricted, these IPC operations can not be used
+// to communicate with a process in a more privileged sandbox domain
+// (e.g. a process in a parent domain or a non-sandboxed process).
+type ScopedSet uint64
+
+var scopedNames = []string{
+	"abstract_unix_socket",
+	"signal",
+}
+
+var supportedScoped = ScopedSet((1 << len(scopedNames)) - 1)
+
+func (a ScopedSet) String() string {
+	return accessSetString(uint64(a), scopedNames)
+}
+
+func (a ScopedSet) isSubset(b ScopedSet) bool {
+	return a&b == a
+}
+
+func (a ScopedSet) intersect(b ScopedSet) ScopedSet {
+	return a & b
+}
+
+func (a ScopedSet) isEmpty() bool {
+	return a == 0
+}
+
+func (a ScopedSet) valid() bool {
+	return a.isSubset(supportedScoped)
+}

--- a/landlock/syscall/landlock.go
+++ b/landlock/syscall/landlock.go
@@ -46,6 +46,15 @@ const (
 	AccessNetConnectTCP
 )
 
+// Landlock scope flags.
+//
+// Please see the full documentation at
+// https://www.kernel.org/doc/html/latest/userspace-api/landlock.html#scope-flags.
+const (
+	ScopeAbstractUnixSocket = 1 << iota
+	ScopeSignal
+)
+
 // RulesetAttr is the Landlock ruleset definition.
 //
 // Argument of LandlockCreateRuleset(). This structure can grow in future versions of Landlock.
@@ -54,10 +63,8 @@ const (
 type RulesetAttr struct {
 	HandledAccessFS  uint64
 	HandledAccessNet uint64
+	Scoped           uint64
 }
-
-// The size of the RulesetAttr struct in bytes.
-const rulesetAttrSize = 16
 
 // PathBeneathAttr references a file hierarchy and defines the desired
 // extent to which it should be usable when the rule is enforced.

--- a/landlock/syscall/syscall_linux.go
+++ b/landlock/syscall/syscall_linux.go
@@ -13,7 +13,7 @@ import (
 // LandlockCreateRuleset creates a ruleset file descriptor with the
 // given attributes.
 func LandlockCreateRuleset(attr *RulesetAttr, flags int) (fd int, err error) {
-	r0, _, e1 := syscall.Syscall(unix.SYS_LANDLOCK_CREATE_RULESET, uintptr(unsafe.Pointer(attr)), uintptr(rulesetAttrSize), uintptr(flags))
+	r0, _, e1 := syscall.Syscall(unix.SYS_LANDLOCK_CREATE_RULESET, uintptr(unsafe.Pointer(attr)), unsafe.Sizeof(*attr), uintptr(flags))
 	fd = int(r0)
 	if e1 != 0 {
 		err = syscall.Errno(e1)


### PR DESCRIPTION
This adds Go-Landlock support for Scoped access rights for IPC between processes,
which were added by @tahifahimi in

https://lore.kernel.org/all/cover.1725657727.git.fahimitahera@gmail.com/
and https://lore.kernel.org/all/cover.1725494372.git.fahimitahera@gmail.com/

A noteworthy difference to C is that in Go, we technically create multiple Landlock domains. All Go programs inherently have multiple goroutines and OS threads.  We enforce the Landlock ruleset on each of these OS threads, but they do technically become separate Landlock domains.  As a result, it becomes dependent on Goroutine scheduling whether IPC between two goroutines is considered to cross the boundary to an "unrelated" Landlock domain.

In order to fix that, I think we'd need to address https://github.com/landlock-lsm/linux/issues/2 first, so that we could apply the same domain on all threads of a process.

Also see the section I added to the documentation:

```
// # Current Limitations (IPC within the same Go program)
//
// For a Go process which restricts Landlock "scoped" IPC operations
// for itself, goroutines within this process might be inconsistently
// permitted or denied to use these IPC mechanisms among themselves.
//
// This is because different OS threads within the Go process may
// technically belong to different Landlock domains (even if these
// domains enforce the same policies).
```
