### PR TITLE
docs: Add additional Landlock information

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 # Go Landlock library
 
 The Go-Landlock library restricts the current processes' ability to
-use files, using Linux 5.13's Landlock feature. ([Package
-documentation](https://pkg.go.dev/github.com/landlock-lsm/go-landlock/landlock))
+use files, using Linux 5.13's Landlock feature. Landlock is useful for
+applications that "run other applications", and such restrictions also
+apply to child processes.
+([Package documentation](https://pkg.go.dev/github.com/landlock-lsm/go-landlock/landlock))
 
 For a more low-level interface, please see [the landlock/syscall
 package](https://pkg.go.dev/github.com/landlock-lsm/go-landlock/landlock/syscall).


### PR DESCRIPTION
This might be a bit redundant because of Landlock's own documentation, but it helps people that have no idea about Landlock understand why they might want it. After all, the modified section is intended to provide people with a "first impression" and attract their interest.