### PR TITLE
Add landrun CLI tool to README under projects using go-landlock

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,10 @@ Goals of Go-Landlock are:
 * Make unprivileged sandboxing easy to use and effective.
 * Keep Go-Landlock's implementation at an easily auditable size.
 
+## Projects Using Go-Landlock
+
+- [landrun](https://github.com/zouuup/landrun): A lightweight CLI sandbox tool using Landlock - think firejail but with kernel-native isolation and no root required.
+
 ## Technical implementation
 
 Some implementation notes that should simplify auditing.


### PR DESCRIPTION
Hey there, I’ve built [landrun](https://github.com/zouuup/landrun), a CLI tool that wraps the go-landlock library into an easy-to-use sandboxing interface for running Linux commands securely.

It’s essentially a firejail-style experience powered entirely by Landlock, with support for filesystem + network restrictions.

Thought it might be useful to link in the README under “Projects Using Go-Landlock” — it helps others see a real-world example of your library in action.

Thanks for making this lib so solid to work with!