### PR TITLE
Fix incorrect information in the human-readable representation of Config

### DIFF
--- a/landlock/config.go
+++ b/landlock/config.go
@@ -135,7 +135,7 @@ func (c Config) String() string {
 
 	var netDesc = c.handledAccessNet.String()
 	if abi.supportedAccessNet == c.handledAccessNet && c.handledAccessNet != 0 {
-		fsDesc = "all"
+		netDesc = "all"
 	}
 
 	var scopedDesc = c.scoped.String()


### PR DESCRIPTION
Currently, if all network access rights are handled then the `String` method will incorrectly say that all *filesystem* access rights are handled.